### PR TITLE
Expand title weight keywords

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -95,10 +95,16 @@ scoring_system:
   title_weights:
     negative:
       senior: -50
+      "sr.": -50
+      kıdemli: -50
+      architect: -50
+      director: -50
       manager: -30
       lead: -20
     positive:
       junior: 40
       entry: 35
       trainee: 30
+      intern: 30
+      stajyer: 30
   threshold: -20


### PR DESCRIPTION
## Summary
- broaden `scoring_system.title_weights` for better seniority detection
- allow intern synonyms for positive scoring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580f11bbdc8331a657555b842a3c3d