### PR TITLE
Fix unconditional no-job return

### DIFF
--- a/src/data_collector.py
+++ b/src/data_collector.py
@@ -78,8 +78,13 @@ def collect_job_data(
                 logger.info(f"ℹ️ '{site}' sitesinden bu arama terimi için ilan bulunamadı.")
 
         except Exception as e:
-            logger.error(f"❌ '{site}' sitesinden veri toplarken hata: {str(e)}", exc_info=True)
-            continue  # Bir sitede hata olursa diğerlerine devam et    if not all_jobs_list:
+            logger.error(
+                f"❌ '{site}' sitesinden veri toplarken hata: {str(e)}",
+                exc_info=True,
+            )
+            continue  # Bir sitede hata olursa diğerlerine devam et
+
+    if not all_jobs_list:
         logger.error("❌ Hiçbir siteden ilan bulunamadı!")
         return None
 

--- a/src/filter.py
+++ b/src/filter.py
@@ -167,9 +167,24 @@ def score_jobs(jobs_list, scoring_system, debug=False):
         if scoring_system.should_include(total):
             scored.append(job)
             if debug:
-                logger.debug(f"✅ Skor {total} ile kabul: {job.get('title', 'N/A')}")
+                logger.debug(f"✅ Skor {total} ile kabul: {job.get('title', 'N/A')} - {details}")
         elif debug:
-            logger.debug(f"🔥 Skor {total} ile reddedildi: {job.get('title', 'N/A')}")
+            logger.debug(f"🔥 Skor {total} ile reddedildi: {job.get('title', 'N/A')} - {details}")
 
     scored.sort(key=lambda x: x["score"], reverse=True)
     return scored
+
+
+def compare_filters(jobs_list, scoring_system, debug=False):
+    """Return comparison of legacy filter and intelligent scoring results."""
+    old_filtered = filter_junior_suitable_jobs(jobs_list, debug=debug)
+    new_filtered = score_jobs(jobs_list, scoring_system, debug=debug)
+
+    old_titles = {job.get("title") for job in old_filtered}
+    new_titles = {job.get("title") for job in new_filtered}
+
+    return {
+        "old_only": list(old_titles - new_titles),
+        "new_only": list(new_titles - old_titles),
+        "intersection": list(old_titles & new_titles),
+    }

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,62 @@
+# Standard Library
+import os
+import sys
+import time
+
+# Third Party
+import yaml
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+# Local
+from src.filter import compare_filters, score_jobs
+from src.intelligent_scoring import IntelligentScoringSystem
+
+
+def load_scoring_system():
+    with open("config.yaml", "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+    return IntelligentScoringSystem(cfg)
+
+
+def test_title_weighting_positive_negative():
+    scoring = load_scoring_system()
+    job = {"title": "Junior Developer", "description": ""}
+    _, details = scoring.score_job(job)
+    assert details["title"] > 0
+
+    job = {"title": "Senior Developer", "description": ""}
+    _, details = scoring.score_job(job)
+    assert details["title"] < 0
+
+
+def test_experience_regex_detection():
+    scoring = load_scoring_system()
+    job = {"title": "Developer", "description": "En az 5 yıl deneyim gereklidir"}
+    _, details = scoring.score_job(job)
+    assert details["experience"] < 0
+
+
+def test_should_include_threshold():
+    scoring = load_scoring_system()
+    job = {"title": "Intern Developer", "description": "0 yıl deneyim"}
+    total, _ = scoring.score_job(job)
+    assert scoring.should_include(total)
+
+
+def test_compare_filters_basic():
+    jobs = [
+        {"title": "Senior Developer", "description": "5 yıl deneyim"},
+        {"title": "Junior Developer", "description": "0 yıl deneyim"},
+    ]
+    scoring = load_scoring_system()
+    result = compare_filters(jobs, scoring)
+    assert "Junior Developer" in result["intersection"]
+    assert "Senior Developer" not in result["intersection"]
+
+
+def test_scoring_performance():
+    scoring = load_scoring_system()
+    jobs = [{"title": "Junior Developer", "description": ""} for _ in range(1000)]
+    start = time.time()
+    score_jobs(jobs, scoring)
+    assert (time.time() - start) < 1.0


### PR DESCRIPTION
## Summary
- fix misplaced check that caused collect_job_data to return None even when results existed
- retain continue behavior for site errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858150a338c8331952759242d91ef25