### PR TITLE
Fix filter empty list

### DIFF
--- a/src/filter.py
+++ b/src/filter.py
@@ -14,6 +14,10 @@ def filter_junior_suitable_jobs(jobs_list, debug=False):
     Junior/Entry-level pozisyonlar için uygun olmayan ilanları filtreler
     YBS öğrencisinin kariyer hedefleri (ERP, Proje Yönetimi, İş Analizi) göz önünde bulundurularak optimizasyon
     """
+    if not jobs_list:
+        logger.info("No jobs provided for filtering.")
+        return []
+
     # Başlık blacklist - SADECE kesinlikle senior olanları hedefler
     title_blacklist = [
         "senior",
@@ -152,7 +156,13 @@ def filter_junior_suitable_jobs(jobs_list, debug=False):
     logger.info(f"   🔥 Sorumluluk filtresi: {filter_stats['responsibility']}")
     logger.info(f"   🔥 Rol dışı filtresi: {filter_stats['out_of_scope']}")
     logger.info(f"   ✅ Geçen: {filter_stats['passed']}")
-    logger.info(f"   📈 Başarı oranı: %{(filter_stats['passed'] / total_processed) * 100:.1f}")
+
+    if total_processed == 0:
+        logger.info("   📈 Başarı oranı: %0.1f", 0.0)
+        logger.info("No jobs were processed.")
+    else:
+        success_rate = (filter_stats["passed"] / total_processed) * 100
+        logger.info(f"   📈 Başarı oranı: %{success_rate:.1f}")
 
     return filtered_jobs
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -8,7 +8,7 @@ import yaml
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 # Local
-from src.filter import compare_filters, score_jobs
+from src.filter import compare_filters, score_jobs, filter_junior_suitable_jobs
 from src.intelligent_scoring import IntelligentScoringSystem
 
 
@@ -60,3 +60,7 @@ def test_scoring_performance():
     start = time.time()
     score_jobs(jobs, scoring)
     assert (time.time() - start) < 1.0
+
+
+def test_filter_empty_list():
+    assert filter_junior_suitable_jobs([]) == []


### PR DESCRIPTION
## Summary
- handle empty jobs list in `filter_junior_suitable_jobs`
- add regression test for empty list behavior

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68582273b2c08331bdb00a13b7d0cd2e