### PR TITLE
Configure VectorStore collection

### DIFF
--- a/main.py
+++ b/main.py
@@ -160,7 +160,10 @@ def analyze_and_find_best_jobs():
 
     # 3. Vector store'u başlat
     logger.info("\n🗃️ 3/6: Vector store hazırlığı...")
-    vector_store = VectorStore()
+    vector_store = VectorStore(
+        persist_directory=config["paths"]["chromadb_dir"],
+        collection_name=config["vector_store_settings"]["collection_name"],
+    )
 
     # 4. İş ilanlarını vector store'a yükle
     logger.info("🔄 4/6: İş ilanları vector store'a yükleniyor...")  # CSV'yi pathlib ile oku


### PR DESCRIPTION
## Summary
- load collection name from config in `VectorStore`
- allow `create_vector_store` to pass a custom collection name
- use config values when starting the vector store

## Testing
- `pytest -q tests/test_scoring.py`

------
https://chatgpt.com/codex/tasks/task_e_6858227624ac83319b81615689ea64a9