### PR TITLE
Ensure flake8 compliance for tests

### DIFF
--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,15 +1,17 @@
-# Standard Library
 import os
 import sys
-import time
-
-# Third Party
-import yaml
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Standard Library
+import time  # noqa: E402
+
+# Third Party
+import yaml  # noqa: E402
+
 # Local
-from src.filter import compare_filters, score_jobs
-from src.intelligent_scoring import IntelligentScoringSystem
+from src.filter import compare_filters, score_jobs  # noqa: E402
+from src.intelligent_scoring import IntelligentScoringSystem  # noqa: E402
 
 
 def load_scoring_system():


### PR DESCRIPTION
## Summary
- adjust imports in `tests/test_scoring.py`
- keep path modification at file start and silence `E402`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582277b1e48331bb82b8e3210ca51f