### PR TITLE
Pass embedding config parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ HEDEFLER:
 GEMINI_API_KEY=AIzaSyC... (gerçek key'iniz)
 ```
 
+#### `config.yaml` Ayarları
+Embedding parametreleri bu dosyada tanımlıdır:
+
+```yaml
+embedding_settings:
+  batch_size: 10       # Batch boyutu
+  retry_count: 3       # Hata durumunda deneme sayısı
+  rate_limit_delay: 0.1  # Saniye cinsinden bekleme
+```
+Bu değerleri ihtiyacınıza göre değiştirebilirsiniz.
+
 ### 2️⃣ İlk Çalıştırma
 
 ```bash

--- a/main.py
+++ b/main.py
@@ -55,6 +55,9 @@ def load_config():
 config = load_config()
 scoring_system = IntelligentScoringSystem(config)
 
+# Embedding ayarları
+embedding_settings = config.get("embedding_settings", {})
+
 # Konfigürasyondan ayarları al
 job_settings = config["job_search_settings"]
 MIN_SIMILARITY_THRESHOLD = job_settings["min_similarity_threshold"]
@@ -146,7 +149,7 @@ def analyze_and_find_best_jobs():
 
     # 2. CV'yi işle
     logger.info("\n📄 2/6: CV analizi...")
-    cv_processor = CVProcessor()
+    cv_processor = CVProcessor(embedding_settings=embedding_settings)
     if not cv_processor.load_cv():
         logger.error("❌ CV yükleme başarısız!")
         return
@@ -184,7 +187,7 @@ def analyze_and_find_best_jobs():
         return
 
     # İş ilanları için embeddings oluştur (tqdm ile)
-    embedding_service = EmbeddingService()
+    embedding_service = EmbeddingService(**embedding_settings)
 
     logger.info("🔄 5/6: İş ilanları için AI embeddings oluşturuluyor...")
     job_embeddings = []

--- a/src/cv_processor.py
+++ b/src/cv_processor.py
@@ -14,9 +14,12 @@ logger = logging.getLogger(__name__)
 
 
 class CVProcessor:
-    def __init__(self, cv_path: Optional[str] = None):
+    def __init__(self, cv_path: Optional[str] = None, embedding_settings: Optional[dict] = None):
         """CV işleyici başlat"""
-        self.embedding_service = EmbeddingService()
+        if embedding_settings:
+            self.embedding_service = EmbeddingService(**embedding_settings)
+        else:
+            self.embedding_service = EmbeddingService()
         self.cv_path = Path(cv_path) if cv_path else Path("data") / "cv.txt"
         self.cv_text = None
         self.cv_embedding = None

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -1,0 +1,51 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.embedding_service import EmbeddingService
+
+
+class Dummy:
+    def __init__(self):
+        self.calls = 0
+
+
+def test_custom_config_applied(monkeypatch):
+    dummy = Dummy()
+
+    def fake_embed_content(model, content, task_type=None):
+        dummy.calls += 1
+        return {"embedding": [0.0]}
+
+    import src.embedding_service as es
+    monkeypatch.setattr(es.genai, "embed_content", fake_embed_content)
+    monkeypatch.setenv("GEMINI_API_KEY", "DUMMY")
+    service = EmbeddingService(batch_size=5, retry_count=2, rate_limit_delay=0)
+    service.create_embeddings_batch(["a", "b", "c"], batch_size=2)
+    assert service.batch_size == 5
+    assert service.retry_count == 2
+    assert service.rate_limit_delay == 0
+    assert dummy.calls == 3
+
+
+def test_retry_logic(monkeypatch):
+    call_count = {"n": 0}
+
+    def fake_embed_content(model, content, task_type=None):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise Exception("fail")
+        return {"embedding": [1.0]}
+
+    import src.embedding_service as es
+    monkeypatch.setattr(es.genai, "embed_content", fake_embed_content)
+    monkeypatch.setattr(__import__("time"), "sleep", lambda x: None)
+    monkeypatch.setenv("GEMINI_API_KEY", "DUMMY")
+    service = EmbeddingService(retry_count=2, rate_limit_delay=0)
+    emb = service.create_embedding("text")
+    assert emb == [1.0]
+    assert call_count["n"] == 2
+


### PR DESCRIPTION
## Summary
- allow configuring EmbeddingService batch size, retry count and rate limiting
- wire embedding_settings from config.yaml in main & CV processor
- document embedding configuration in README
- test EmbeddingService config usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685822793c648331875e54dc9c93c2d7