### PR TITLE
Concurrent job scraping

### DIFF
--- a/tests/test_data_collector.py
+++ b/tests/test_data_collector.py
@@ -1,0 +1,37 @@
+# Standard Library
+import os
+import sys
+import time
+
+# Third Party
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Local
+from src.data_collector import collect_job_data
+
+
+def test_concurrent_scraping(monkeypatch):
+    call_times = []
+
+    def fake_scrape_jobs(**kwargs):
+        call_times.append(time.time())
+        time.sleep(0.2)
+        return pd.DataFrame(
+            [
+                {
+                    "title": f"t-{kwargs['site_name']}",
+                    "company": "c",
+                    "location": "l",
+                }
+            ]
+        )
+
+    monkeypatch.setattr("src.data_collector.scrape_jobs", fake_scrape_jobs)
+    start = time.time()
+    df = collect_job_data("x", site_names=["a", "b"], max_results_per_site=1, hours_old=1)
+    duration = time.time() - start
+    assert len(df) == 2
+    assert duration < 0.4
+    assert max(call_times) - min(call_times) < 0.3


### PR DESCRIPTION
## Summary
- run each job site scrape in parallel via `ThreadPoolExecutor`
- add a regression test checking scrapes run concurrently

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582f9b900c8331b45b85330350c500