### PR TITLE
Add filter test for senior positions

### DIFF
--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.filter import filter_junior_suitable_jobs
+
+
+def test_senior_jobs_filtered_junior_jobs_kept():
+    jobs = [
+        {"title": "Senior Developer", "description": "5+ yıl deneyim, takım yönetimi"},
+        {"title": "Junior Developer", "description": "0 yıl deneyim"},
+    ]
+    filtered = filter_junior_suitable_jobs(jobs)
+    titles = [j["title"] for j in filtered]
+    assert "Junior Developer" in titles
+    assert "Senior Developer" not in titles


### PR DESCRIPTION
## Summary
- add a unit test covering filter_junior_suitable_jobs
- ensure senior listings are removed while junior ones remain

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68582f9be25083318288ccc040d68990