### PR TITLE
Add dev requirements and setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ source kariyer-asistani-env/bin/activate
 
 # 4. Bağımlılıkları yükleyin
 pip install -r requirements.txt
+# test ve gelistirme icin
+pip install -e .[dev]
 
 # 5. API key'inizi ayarlayın
 # .env dosyası oluşturun ve içine ekleyin:
@@ -657,6 +659,7 @@ kariyer-asistani/
 - [ ] ✅ `git clone` ile projeyi indirdim
 - [ ] ✅ `python -m venv` ile sanal ortam oluşturdum
 - [ ] ✅ `pip install -r requirements.txt` çalıştırdım
+- [ ] ✅ `pip install -e .[dev]` ile test/gelistirme bagimliliklarini kurdum
 - [ ] ✅ Gemini API key aldım ve `.env` dosyasına ekledim
 - [ ] ✅ `data/` klasörünü oluşturdum
 - [ ] ✅ `data/cv.txt` dosyasına CV'mi yazdım
@@ -808,6 +811,8 @@ Bu proje açık kaynaklıdır ve topluluğun katkılarıyla büyür. Her seviyed
 3. **💻 Geliştirme yapın**
    ```bash
    # Kodunuzu yazın
+   # Geliştirme bagimliliklarini kurmak icin
+pip install -e .[dev]
    # Testlerinizi çalıştırın
    python -m pytest tests/
    ```

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Simple setup script for development
+set -e
+python -m pip install --upgrade pip
+pip install -e .[dev]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+pytest>=7.0.0
+pytest-cov>=4.0.0
+black>=23.12.0
+flake8>=6.1.0
+isort>=5.13.2


### PR DESCRIPTION
## Summary
- document installing dev dependencies
- add `requirements-dev.txt`
- add simple `dev-setup.sh` script for local setup

## Testing
- `python -m pytest -q` *(fails: Bus error)*

------
https://chatgpt.com/codex/tasks/task_e_68582f9ccc2c8331970ba552c49a4bbd