### PR TITLE
Extend description scoring

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -107,4 +107,9 @@ scoring_system:
       trainee: 30
       intern: 30
       stajyer: 30
+  description_weights:
+    negative:
+      management: -20
+    positive:
+      remote: 15
   threshold: -20

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -36,6 +36,17 @@ def test_experience_regex_detection():
     assert details["experience"] < 0
 
 
+def test_description_keyword_scoring():
+    scoring = load_scoring_system()
+    positive_job = {"title": "Developer", "description": "Remote work available"}
+    _, details_pos = scoring.score_job(positive_job)
+    assert details_pos["description"] > 0
+
+    negative_job = {"title": "Developer", "description": "Management experience"}
+    _, details_neg = scoring.score_job(negative_job)
+    assert details_neg["description"] < 0
+
+
 def test_should_include_threshold():
     scoring = load_scoring_system()
     job = {"title": "Intern Developer", "description": "0 yıl deneyim"}


### PR DESCRIPTION
## Summary
- add `description_weights` section in config
- score job descriptions using keyword patterns
- include description score in total
- test description keyword scoring

## Testing
- `pytest tests/test_scoring.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68584266a4f48331997bf93f15225385