### PR TITLE
Implement deduplication and vector store improvements

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -47,8 +47,8 @@ persona_search_configs:
     results: 25
 
   Data_Analyst:
-    term: "(\"Data Analyst\" OR \"Veri Analisti\") (SQL OR Python OR PowerBI OR Tableau) -Senior -Lead"
-    hours_old: 72
+    term: "(\"Data Analyst\" OR \"Veri Analisti\" OR \"BI Analyst\" OR \"Business Intelligence\") (SQL OR Python OR PowerBI OR Tableau) -Senior -Lead"
+    hours_old: 168
     results: 25
 
   ERP_Consultant:
@@ -62,8 +62,8 @@ persona_search_configs:
     results: 25
 
   IT_Analyst:
-    term: "(\"IT Analyst\" OR \"BT Analisti\" OR \"System Analyst\" OR \"Sistem Analisti\") -Senior -Lead"
-    hours_old: 72
+    term: "(\"IT Analyst\" OR \"BT Analisti\" OR \"System Analyst\" OR \"Sistem Analisti\" OR \"Technical Support\") -Senior -Lead"
+    hours_old: 168
     results: 25
 
   Junior_General_Tech:

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -20,6 +20,13 @@ def test_stable_job_id_consistency():
     assert first == second
 
 
+def test_stable_job_id_uses_url():
+    job1 = {"title": "Dev", "description": "desc", "url": "http://example.com/1"}
+    job2 = {"title": "Dev", "description": "desc", "url": "http://example.com/1", "persona_source": "A"}
+    vs = VectorStore()
+    assert vs._stable_job_id(job1) == vs._stable_job_id(job2)
+
+
 def test_duplicate_detection_across_runs():
     job = {"title": "Dev", "description": "desc"}
     df = pd.DataFrame([job])


### PR DESCRIPTION
## Summary
- avoid concat warnings for empty DataFrames
- deduplicate high quality job results by title/company/url
- skip embeddings for jobs already stored
- compute vector store IDs using job URLs and expose `job_exists`
- widen Data_Analyst and IT_Analyst search terms
- add regression test for URL-based job IDs

## Testing
- `make format`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68585aed42d883318e29b1aa93f6390d