### PR TITLE
Add CV similarity bonus scoring

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -131,3 +131,5 @@ scoring_system:
     "3": -10
   cv_skill_keywords: []
   threshold: -20
+  cv_skill_boost_threshold: 0.8
+  cv_skill_bonus_points: 10

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -572,3 +572,21 @@ def test_regression_protection_basic_scores():
         total, _ = scoring.score_job(case["job"])
         assert case["min_score"] <= total <= case["max_score"], \
             f"Regression test failed for {case['job']}: expected {case['min_score']}-{case['max_score']}, got {total}"
+
+
+def test_calculate_total_score_bonus_applied():
+    with open("config.yaml", "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+    scoring = IntelligentScoringSystem(cfg, cv_embedding=[1.0, 0.0])
+    base = 5
+    boosted = scoring.calculate_total_score(base, job_embedding=[1.0, 0.0])
+    assert boosted == base + scoring.cv_skill_bonus_points
+
+
+def test_calculate_total_score_no_bonus():
+    with open("config.yaml", "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+    scoring = IntelligentScoringSystem(cfg, cv_embedding=[1.0, 0.0])
+    base = 5
+    result = scoring.calculate_total_score(base, job_embedding=[0.0, 1.0])
+    assert result == base


### PR DESCRIPTION
## Summary
- extend `config.yaml` with `cv_skill_boost_threshold` and `cv_skill_bonus_points`
- add cosine similarity based bonus scoring in `IntelligentScoringSystem`
- include new unit tests for the bonus logic

## Testing
- `make format`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685887713c508331a33ac6e0581f56c4