### PR TITLE
Implement CV analyzer and dynamic scoring

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -133,3 +133,4 @@ scoring_system:
   threshold: -20
   cv_skill_boost_threshold: 0.8
   cv_skill_bonus_points: 10
+  dynamic_skill_weight: 10

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from dotenv import load_dotenv
 from tqdm import tqdm
 
 # Local
+from src.cv_analyzer import CVAnalyzer
 from src.cv_processor import CVProcessor
 from src.data_collector import collect_job_data
 from src.embedding_service import EmbeddingService
@@ -53,7 +54,6 @@ def load_config():
 
 # Konfigürasyonu yükle
 config = load_config()
-scoring_system = IntelligentScoringSystem(config)
 
 # Embedding ayarları
 embedding_settings = config.get("embedding_settings", {})
@@ -165,6 +165,13 @@ def analyze_and_find_best_jobs(selected_personas=None, results_per_site=None, si
 
     cv_embedding = cv_processor.cv_embedding
     logger.info("✅ CV embedding oluşturuldu")
+
+    # Dynamically analyze CV for skills and titles
+    cv_text = cv_processor.get_cv_text()
+    analyzer = CVAnalyzer(cache_dir=config["paths"]["data_dir"])
+    metadata = analyzer.extract_metadata_from_cv(cv_text)
+    config["scoring_system"]["dynamic_skill_keywords"] = metadata.get("key_skills", [])
+    scoring_system = IntelligentScoringSystem(config)
 
     # 3. Vector store'u başlat
     logger.info("\n🗃️ 3/6: Vector store hazırlığı...")

--- a/src/cv_analyzer.py
+++ b/src/cv_analyzer.py
@@ -1,0 +1,117 @@
+"""CV Analyzer: Extract key skills and job titles from CV text.
+
+This module provides basic CV analysis with caching and skill normalization.
+"""
+
+# Standard Library
+import hashlib
+import json
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+SKILL_BLACKLIST = {
+    "ms office",
+    "msoffice",
+    "microsoft office",
+    "word",
+    "excel",
+    "powerpoint",
+    "windows",
+    "email",
+    "internet",
+    "computer",
+    "keyboard",
+}
+
+COMMON_SKILLS = {
+    "python",
+    "sql",
+    "react",
+    "javascript",
+    "project management",
+    "data analysis",
+    "powerbi",
+    "tableau",
+}
+
+COMMON_TITLES = {"developer", "analyst", "engineer", "consultant"}
+
+
+class CVAnalyzer:
+    """Analyze CV text and cache extracted metadata."""
+
+    def __init__(self, cache_dir: str | Path = "data", token_limit: int = 4000) -> None:
+        self.cache_dir = Path(cache_dir)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.token_limit = token_limit
+
+    # Caching utilities
+    def get_cache_key(self, cv_text: str) -> str:
+        return hashlib.sha256(cv_text.encode("utf-8")).hexdigest()[:16]
+
+    def _cache_file(self, cv_text: str) -> Path:
+        return self.cache_dir / f"meta_{self.get_cache_key(cv_text)}.json"
+
+    def load_cached_metadata(self, cv_text: str) -> Optional[dict]:
+        path = self._cache_file(cv_text)
+        if not path.exists():
+            return None
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            ts = data.get("generated_at")
+            if ts and datetime.now() - datetime.fromisoformat(ts) < timedelta(days=7):
+                logger.info("♻️  Önbellekten CV verisi kullanıldı")
+                return data
+        except Exception as e:  # noqa: BLE001
+            logger.error("Önbellek okunamadı: %s", e, exc_info=True)
+        return None
+
+    def cache_metadata(self, cv_text: str, metadata: dict) -> None:
+        cache_data = {
+            "metadata": metadata,
+            "generated_at": datetime.now().isoformat(),
+            "cv_hash": self.get_cache_key(cv_text),
+        }
+        path = self._cache_file(cv_text)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(cache_data, f, ensure_ascii=False, indent=2)
+        logger.info("📁 CV analizi önbelleğe kaydedildi: %s", path)
+
+    # Normalization helpers
+    def normalize_skills(self, skills: List[str]) -> List[str]:
+        normalized = []
+        for skill in skills:
+            clean = skill.lower().replace(" ", "").replace("-", "")
+            if clean not in SKILL_BLACKLIST and len(clean) > 2:
+                normalized.append(clean)
+        # Remove duplicates
+        return list(set(normalized))
+
+    def extract_metadata_from_cv(self, cv_text: str) -> dict:
+        if not cv_text:
+            return {"key_skills": [], "target_job_titles": []}
+        cached = self.load_cached_metadata(cv_text)
+        if cached:
+            return cached["metadata"]
+
+        text = cv_text[: self.token_limit]
+        skills_found = [s for s in COMMON_SKILLS if s.lower() in text.lower()]
+        titles_found = [t.title() for t in COMMON_TITLES if t.lower() in text.lower()]
+        metadata = {
+            "key_skills": self.normalize_skills(skills_found),
+            "target_job_titles": titles_found,
+        }
+        self.cache_metadata(cv_text, metadata)
+        return metadata
+
+
+if __name__ == "__main__":  # Simple manual test
+    sample_text = "Python developer with SQL and React experience. Proficient in PowerBI."
+    analyzer = CVAnalyzer()
+    meta = analyzer.extract_metadata_from_cv(sample_text)
+    logger.info("Extracted metadata: %s", meta)

--- a/src/intelligent_scoring.py
+++ b/src/intelligent_scoring.py
@@ -60,6 +60,8 @@ class IntelligentScoringSystem:
         desc_weights_cfg = scoring_cfg.get("description_weights", {})
         exp_penalty_cfg = scoring_cfg.get("experience_penalties", {"5": -40, "4": -20})
         cv_cfg = scoring_cfg.get("cv_skill_keywords", {})
+        dynamic_skills = scoring_cfg.get("dynamic_skill_keywords", [])
+        dynamic_weight = int(scoring_cfg.get("dynamic_skill_weight", 10))
 
         self.title_patterns = {
             "negative": _compile_patterns_from_config(title_cfg.get("negative", [])),
@@ -69,6 +71,11 @@ class IntelligentScoringSystem:
             "negative": _compile_weighted_patterns(desc_weights_cfg.get("negative", {})),
             "positive": _compile_weighted_patterns(desc_weights_cfg.get("positive", {})),
         }
+        # Inject dynamic skills with uniform weight
+        if dynamic_skills:
+            for skill in dynamic_skills:
+                pattern = _create_regex_pattern(skill)
+                self.description_weights.setdefault("positive", []).append((pattern, dynamic_weight))
         self.experience_penalties = {int(k): int(v) for k, v in exp_penalty_cfg.items()}
         self.cv_skill_patterns = _compile_patterns_from_config(
             cv_cfg

--- a/tests/test_cv_analyzer.py
+++ b/tests/test_cv_analyzer.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from src.cv_analyzer import CVAnalyzer
+
+
+def test_normalization_and_blacklist(tmp_path):
+    analyzer = CVAnalyzer(cache_dir=tmp_path)
+    skills = analyzer.normalize_skills(["Python", "MS Office", "react-js", "python"])
+    assert "python" in skills
+    assert "reactjs" in skills
+    assert "msoffice" not in skills
+
+
+def test_cache_write_and_read(tmp_path):
+    analyzer = CVAnalyzer(cache_dir=tmp_path)
+    text = "Python developer with SQL"
+    data = {"key_skills": ["python", "sql"], "target_job_titles": ["Developer"]}
+    analyzer.cache_metadata(text, data)
+    loaded = analyzer.load_cached_metadata(text)
+    assert loaded is not None
+    assert loaded["metadata"] == data
+    # ensure timestamp is present
+    assert "generated_at" in loaded


### PR DESCRIPTION
## Summary
- add new `CVAnalyzer` module with caching and skill normalization
- inject dynamic skills into scoring via `IntelligentScoringSystem`
- update config to support `dynamic_skill_weight`
- integrate `CVAnalyzer` in `main.py`
- add unit tests for CV analyzer

## Testing
- `make format`
- `make lint`
- `make test`
- `make quality-check` *(fails: No rule to make target 'quality-check')*

------
https://chatgpt.com/codex/tasks/task_e_6858958277e883318cc897e9dad04c70