### PR TITLE
Implement CV analyzer and dynamic scoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,6 @@ lint:
 	@echo "✅ Kod kalitesi kontrolü tamamlandı"
 
 # Test çalıştırma
-test:
-	python -m pytest tests/ -v --cov=src
-	@echo "✅ Testler tamamlandı"
-
 # Ana uygulama
 run:
 	python main.py
@@ -61,3 +57,10 @@ clean:
 # Hızlı geliştirme döngüsü
 dev-check: format lint
 	@echo "✅ Geliştirme kontrolleri tamamlandı"
+# Test çalıştırma
+test:
+	python -m pytest tests/ -v --cov=src
+	@echo "✅ Testler tamamlandı"
+
+quality-check: format lint test
+	@echo "✅ Kod kalitesi kontrolü tamamlandı"

--- a/config.yaml
+++ b/config.yaml
@@ -133,3 +133,4 @@ scoring_system:
   threshold: -20
   cv_skill_boost_threshold: 0.8
   cv_skill_bonus_points: 10
+  dynamic_skill_weight: 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "PyYAML>=6.0.1",
     "tqdm>=4.66.1",
+    "tenacity>=8.2.3",
     "sentence-transformers>=3.0.1",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ numpy==1.26.3
 python-dotenv==1.0.1
 PyYAML==6.0.1
 tqdm==4.66.1
+tenacity==8.2.3
 
 # Geliştirme (Opsiyonel)
 black==23.12.0

--- a/src/cv_analyzer.py
+++ b/src/cv_analyzer.py
@@ -1,0 +1,162 @@
+"""CV Analyzer: Extract key skills and job titles from CV text.
+
+This module provides basic CV analysis with caching and skill normalization.
+"""
+
+# Standard Library
+import hashlib
+import json
+import logging
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List, Optional
+
+# Third Party
+import google.generativeai as genai
+from dotenv import load_dotenv
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+logger = logging.getLogger(__name__)
+
+SKILL_BLACKLIST = {
+    "ms office",
+    "msoffice",
+    "microsoft office",
+    "word",
+    "excel",
+    "powerpoint",
+    "windows",
+    "email",
+    "internet",
+    "computer",
+    "keyboard",
+}
+
+COMMON_SKILLS = {
+    "python",
+    "sql",
+    "react",
+    "javascript",
+    "project management",
+    "data analysis",
+    "powerbi",
+    "tableau",
+}
+
+COMMON_TITLES = {"developer", "analyst", "engineer", "consultant"}
+
+
+class CVAnalyzer:
+    """Analyze CV text and cache extracted metadata."""
+
+    def __init__(self, cache_dir: str | Path = "data", token_limit: int = 4000) -> None:
+        self.cache_dir = Path(cache_dir)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.token_limit = token_limit
+
+        load_dotenv()
+        api_key = os.getenv("GEMINI_API_KEY")
+        if not api_key or api_key == "your_gemini_api_key_here":
+            logger.warning("GEMINI_API_KEY bulunamadı, yerleşik kurallar kullanılacak")
+            self.model = None
+        else:
+            genai.configure(api_key=api_key)
+        self.model = genai.GenerativeModel("gemini-pro")
+
+    @retry(
+        reraise=True,
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=5),
+        retry=retry_if_exception_type(Exception),
+    )
+    def _call_gemini_api(self, prompt: str) -> str:
+        if not self.model:
+            raise RuntimeError("Gemini modeli tanimsiz")
+        response = self.model.generate_content(prompt)
+        return response.text
+
+    # Caching utilities
+    def get_cache_key(self, cv_text: str) -> str:
+        return hashlib.sha256(cv_text.encode("utf-8")).hexdigest()[:16]
+
+    def _cache_file(self, cv_text: str) -> Path:
+        return self.cache_dir / f"meta_{self.get_cache_key(cv_text)}.json"
+
+    def load_cached_metadata(self, cv_text: str) -> Optional[dict]:
+        path = self._cache_file(cv_text)
+        if not path.exists():
+            return None
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            ts = data.get("generated_at")
+            if ts and datetime.now() - datetime.fromisoformat(ts) < timedelta(days=7):
+                logger.info("♻️  Önbellekten CV verisi kullanıldı")
+                return data
+        except Exception as e:  # noqa: BLE001
+            logger.error("Önbellek okunamadı: %s", e, exc_info=True)
+        return None
+
+    def cache_metadata(self, cv_text: str, metadata: dict) -> None:
+        cache_data = {
+            "metadata": metadata,
+            "generated_at": datetime.now().isoformat(),
+            "cv_hash": self.get_cache_key(cv_text),
+        }
+        path = self._cache_file(cv_text)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(cache_data, f, ensure_ascii=False, indent=2)
+        logger.info("📁 CV analizi önbelleğe kaydedildi: %s", path)
+
+    # Normalization helpers
+    def normalize_skills(self, skills: List[str]) -> List[str]:
+        normalized = []
+        for skill in skills:
+            clean = skill.lower().replace(" ", "").replace("-", "")
+            if clean not in SKILL_BLACKLIST and len(clean) > 2:
+                normalized.append(clean)
+        # Remove duplicates
+        return list(set(normalized))
+
+    def extract_metadata_from_cv(self, cv_text: str) -> dict:
+        if not cv_text:
+            return {"key_skills": [], "target_job_titles": []}
+
+        cached = self.load_cached_metadata(cv_text)
+        if cached:
+            return cached["metadata"]
+
+        text = cv_text[: self.token_limit]
+        prompt = (
+            "You are an expert career advisor. "
+            "Extract up to 8 key professional skills and up to 3 target job titles "
+            "from the following CV text. Return JSON with keys 'key_skills' and 'target_job_titles'.\nCV:\n" + text
+        )
+
+        try:
+            if self.model:
+                response_text = self._call_gemini_api(prompt)
+                parsed = json.loads(response_text)
+                skills = parsed.get("key_skills", [])
+                titles = parsed.get("target_job_titles", [])
+            else:
+                raise RuntimeError("Gemini modeli kullanılmıyor")
+        except Exception as e:  # noqa: BLE001
+            logger.error("Gemini API hatası: %s", e, exc_info=True)
+            skills = [s for s in COMMON_SKILLS if s.lower() in text.lower()]
+            titles = [t.title() for t in COMMON_TITLES if t.lower() in text.lower()]
+
+        metadata = {
+            "key_skills": self.normalize_skills(skills),
+            "target_job_titles": titles,
+        }
+        self.cache_metadata(cv_text, metadata)
+        return metadata
+
+
+if __name__ == "__main__":  # Simple manual test
+    sample_text = "Python developer with SQL and React experience. Proficient in PowerBI."
+    analyzer = CVAnalyzer()
+    meta = analyzer.extract_metadata_from_cv(sample_text)
+    logger.info("Extracted metadata: %s", meta)

--- a/src/intelligent_scoring.py
+++ b/src/intelligent_scoring.py
@@ -60,6 +60,8 @@ class IntelligentScoringSystem:
         desc_weights_cfg = scoring_cfg.get("description_weights", {})
         exp_penalty_cfg = scoring_cfg.get("experience_penalties", {"5": -40, "4": -20})
         cv_cfg = scoring_cfg.get("cv_skill_keywords", {})
+        dynamic_skills = scoring_cfg.get("dynamic_skill_keywords", [])
+        dynamic_weight = int(scoring_cfg.get("dynamic_skill_weight", 10))
 
         self.title_patterns = {
             "negative": _compile_patterns_from_config(title_cfg.get("negative", [])),
@@ -69,6 +71,11 @@ class IntelligentScoringSystem:
             "negative": _compile_weighted_patterns(desc_weights_cfg.get("negative", {})),
             "positive": _compile_weighted_patterns(desc_weights_cfg.get("positive", {})),
         }
+        # Inject dynamic skills with uniform weight
+        if dynamic_skills:
+            for skill in dynamic_skills:
+                pattern = _create_regex_pattern(skill)
+                self.description_weights.setdefault("positive", []).append((pattern, dynamic_weight))
         self.experience_penalties = {int(k): int(v) for k, v in exp_penalty_cfg.items()}
         self.cv_skill_patterns = _compile_patterns_from_config(
             cv_cfg

--- a/src/persona_builder.py
+++ b/src/persona_builder.py
@@ -1,0 +1,23 @@
+"""Dynamic persona builder.
+
+Convert job titles provided by AI into JobSpy-compatible search configurations."""
+
+from __future__ import annotations
+
+# Standard Library
+import re
+from typing import Dict, List
+
+NEGATIVE_FILTERS = "-Senior -Lead -Manager -Director -Principal"
+
+
+def build_dynamic_personas(
+    job_titles: List[str], hours_old: int = 72, results: int = 25
+) -> Dict[str, Dict[str, str | int]]:
+    """Build search configs from job titles."""
+    personas: Dict[str, Dict[str, str | int]] = {}
+    for title in job_titles or []:
+        cleaned = re.sub(r"\W+", "_", title).strip("_")
+        term = f'("{title}") {NEGATIVE_FILTERS}'
+        personas[cleaned] = {"term": term, "hours_old": hours_old, "results": results}
+    return personas

--- a/tests/test_cv_analyzer.py
+++ b/tests/test_cv_analyzer.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from src.cv_analyzer import CVAnalyzer
+
+
+def test_normalization_and_blacklist(tmp_path):
+    analyzer = CVAnalyzer(cache_dir=tmp_path)
+    skills = analyzer.normalize_skills(["Python", "MS Office", "react-js", "python"])
+    assert "python" in skills
+    assert "reactjs" in skills
+    assert "msoffice" not in skills
+
+
+def test_cache_write_and_read(tmp_path):
+    analyzer = CVAnalyzer(cache_dir=tmp_path)
+    text = "Python developer with SQL"
+    data = {"key_skills": ["python", "sql"], "target_job_titles": ["Developer"]}
+    analyzer.cache_metadata(text, data)
+    loaded = analyzer.load_cached_metadata(text)
+    assert loaded is not None
+    assert loaded["metadata"] == data
+    # ensure timestamp is present
+    assert "generated_at" in loaded

--- a/tests/test_persona_builder.py
+++ b/tests/test_persona_builder.py
@@ -1,0 +1,12 @@
+from src.persona_builder import build_dynamic_personas
+
+
+def test_build_dynamic_personas_basic():
+    titles = ["Python Developer", "Data Analyst"]
+    personas = build_dynamic_personas(titles)
+    assert "Python_Developer" in personas
+    cfg = personas["Python_Developer"]
+    assert "Python Developer" in cfg["term"]
+    assert "-Senior" in cfg["term"]
+    assert cfg["hours_old"] == 72
+    assert cfg["results"] == 25


### PR DESCRIPTION
## Summary
- add Gemini-based metadata extraction with caching
- introduce `build_dynamic_personas` helper
- allow dynamic personas and skills in main workflow
- add `quality-check` target in Makefile
- include `tenacity` dependency and unit tests for persona builder

## Testing
- `make format`
- `make lint`
- `make test` *(fails: bus error in chromadb)*
- `make quality-check` *(fails: bus error in chromadb)*

------
https://chatgpt.com/codex/tasks/task_e_6858958277e883318cc897e9dad04c70