### PR TITLE
feat: dynamic scoring and reporting

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -89,3 +89,4 @@ scoring_system:
   cv_skill_boost_threshold: 0.8
   cv_skill_bonus_points: 10
   dynamic_skill_weight: 10
+  min_importance_for_scoring: 0.75

--- a/src/persona_builder.py
+++ b/src/persona_builder.py
@@ -2,12 +2,25 @@ from __future__ import annotations
 
 """Utilities for building persona configs dynamically."""
 
+ROLE_RESULTS = {
+    "developer": 30,
+    "analyst": 25,
+}
+
+DEFAULT_RESULTS = 20
+
 
 def build_dynamic_personas(target_job_titles: list[str]) -> dict[str, dict[str, object]]:
-    """Convert job titles into persona search configs."""
+    """Convert job titles into persona search configs with dynamic results."""
     personas: dict[str, dict[str, object]] = {}
     for title in target_job_titles or []:
         key = title.strip().replace(" ", "_")
         term = f'("{title}" OR "{title}") -Senior -Lead'
-        personas[key] = {"term": term, "hours_old": 72, "results": 25}
+        role_lower = title.lower()
+        results = DEFAULT_RESULTS
+        for role, count in ROLE_RESULTS.items():
+            if role in role_lower:
+                results = count
+                break
+        personas[key] = {"term": term, "hours_old": 72, "results": results}
     return personas

--- a/tests/test_persona_builder.py
+++ b/tests/test_persona_builder.py
@@ -1,3 +1,5 @@
+import pytest
+
 from src.persona_builder import build_dynamic_personas
 
 
@@ -8,3 +10,17 @@ def test_build_dynamic_personas_simple():
     term = personas["Business_Analyst"]["term"]
     assert "Business Analyst" in term
     assert personas["Data_Analyst"]["hours_old"] == 72
+
+
+@pytest.mark.parametrize(
+    "titles,expected",
+    [
+        (["Junior GIS Specialist"], 20),
+        (["React Developer"], 30),
+        (["Chief Executive Officer"], 20),
+    ],
+)
+def test_dynamic_result_counts(titles, expected):
+    personas = build_dynamic_personas(titles)
+    key = titles[0].replace(" ", "_")
+    assert personas[key]["results"] == expected


### PR DESCRIPTION
Closes #XX

### **1. Summary (Özet)**

Adds AI-driven skill weighting, persona-specific result counts, and summary reporting to the job search pipeline.

### **2. Problem & Motivation (Problem ve Motivasyon)**

Static weights and generic persona searches limited result relevance and provided no insight into job distribution.

### **3. Solution Implemented (Uygulanan Çözüm)**

- Config supports importance threshold via `min_importance_for_scoring`.
- `_configure_scoring_system` now weights skills using importance values.
- `build_dynamic_personas` assigns result counts per role.
- New `log_summary_statistics` reports site distribution, skill mentions and persona success.
- Pipeline logs these stats after running.
- Added tests covering new behaviour.

### **4. Validation & Testing (Doğrulama ve Test)**

- **Quality Checks:**
  - `ruff`: ✅
  - `mypy`: ✅
  - `bandit`: ✅
- **Tests:**
  - `pytest`: ✅ 132 passed.
- **Manual Verification:**
  - CLI help invoked successfully.


------
https://chatgpt.com/codex/tasks/task_e_685baa5177688331ba022e7064993ed5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added summary statistics logging for job sources, skill occurrences, and persona sources in reporting.
- **Improvements**
  - Skill weights in scoring now only apply to skills meeting a minimum importance threshold.
  - Persona result counts are now dynamically assigned based on job title content.
- **Bug Fixes**
  - Defensive handling of CSV reading in the results pipeline to prevent errors.
- **Tests**
  - Updated and expanded tests to cover new skill weighting logic and dynamic persona result counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->