### PR TITLE
feat: externalize prompts and add constants

### DIFF
--- a/prompts/cv_analysis_prompt.md
+++ b/prompts/cv_analysis_prompt.md
@@ -1,0 +1,65 @@
+**ROLE:** You are an *expert* Career Strategist for **Management Information
+Systems (MIS / YBS)** professionals who also possess strong full-stack and data
+science skills.
+
+**PRIME DIRECTIVE:** The candidate is an MIS student—not a pure software
+developer.  Your analysis *must* prioritise business-technology bridge roles
+(e.g. ERP consultant, process analyst).  Failing to do so is a critical error.
+
+**CONTEXT (read carefully):**
+• Strong full-stack: NestJS, React, TypeScript, Flutter
+• Advanced data analytics & ML (Python / Pandas / XGBoost)
+• ERP & Business-Process focus (SAP, requirement & process improvement)
+• GIS niche (QGIS, PostGIS, Leaflet.js)
+
+**RESUME TEXT:**
+---
+{cv_text}
+---
+
+**TASK – Return **ONLY** a raw JSON object (no markdown, no commentary).**
+
+1. `"key_skills"`   📋 *array [str]* – top 20-25 skills, ordered by PRIORITY.
+   * **PRIORITY 1 (MUST include):** MIS/Business/Process Skills -> ERP, SAP,
+     business_process_improvement, system_analysis, requirement_analysis,
+     agile, scrum, project_management
+   * **PRIORITY 2:** Core Software & Data Tech -> nestjs, react, python,
+     typescript, postgresql, data_analysis, machine_learning
+   * **PRIORITY 3 (Niche/Supporting):** GIS / Geospatial Skills -> gis, qgis,
+     postgis, leafletjs
+   * Normalise: lowercase, snake_case, no spaces/dashes (`"process_improvement"`).
+
+2. `"target_job_titles"`   🎯 *array [str]* – 12-16 junior / entry / associate
+   titles **ordered by best fit**.
+   **≥ 60 %** of items *must* be MIS / Business / ERP / Data focused. Software roles are secondary.
+   Mandatory buckets (if CV supports):
+   - Business / Process Roles: “Business Analyst”, “Process Analyst”,
+     “Business Systems Analyst”, “Junior Project Manager”
+   - ERP / Consulting Roles: “Junior ERP Consultant”, “IT Consultant”
+   - Hybrid Roles: “Technical Business Analyst”, “Data Analyst”
+ - Dev Roles (max 30-40 %): “Full-Stack Developer”, “Mobile Developer (Flutter)”
+  - **GIS Roles (if any, place at the end of the list):** “GIS Specialist”
+
+3. `"skill_importance"`   ⭐ *array [float]* – same length as `key_skills`,
+   values 0.00-1.00 (2 decimals).  Reflect how central the skill is to the
+   candidate’s profile & projects.
+
+4. `"cv_summary"` 🗄 *string* – 2-3 sentence professional summary of the candidate.
+
+**JSON SCHEMA (enforced):**
+{
+  "type": "object",
+ "properties": {
+    "key_skills":        {"type": "array", "items": {"type": "string"}},
+    "target_job_titles": {"type": "array", "items": {"type": "string"}},
+    "skill_importance":  {"type": "array", "items": {"type":"number"}},
+    "cv_summary":       {"type": "string"}
+  },
+  "required": ["key_skills", "target_job_titles", "skill_importance", "cv_summary"]
+}
+
+**ABSOLUTE RULES:**
+* Do **NOT** wrap the JSON with ``` or any extra text.
+* Exclude generic office basics (“ms office”, “excel”, “windows”, …).
+* Ensure array lengths match; ordering in `key_skills` ↔ `skill_importance`
+  must correspond.

--- a/prompts/rerank_prompt.md
+++ b/prompts/rerank_prompt.md
@@ -1,0 +1,13 @@
+You are an expert career assistant. Candidate summary: {cv_summary}
+
+JOB TITLE: {title}
+JOB DESCRIPTION: {description}
+
+Return ONLY JSON with fields:
+{
+  "fit_score": int,          # 0-100 suitability
+  "is_recommended": bool,    # True if worth applying
+  "reasoning": str,          # short reasoning
+  "matching_keywords": [str],
+  "missing_keywords": [str]
+}

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+COSINE_METRIC = "cosine"
+DEFAULT_COLLECTION_NAME = "job_embeddings"
+SITE_LINKEDIN = "linkedin"
+SITE_INDEED = "indeed"
+PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"

--- a/src/cv_analyzer.py
+++ b/src/cv_analyzer.py
@@ -10,11 +10,16 @@ from pathlib import Path
 from typing import cast
 
 import google.generativeai as genai
+from dotenv import load_dotenv
 
 # Third Party
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from .config import get_config
+from .constants import PROMPTS_DIR
+from .utils.prompt_loader import load_prompt
+
+load_dotenv(dotenv_path=PROMPTS_DIR.parent / ".env")
 
 logger = logging.getLogger(__name__)
 
@@ -38,73 +43,7 @@ SKILL_BLACKLIST = {
 }
 NORMALIZED_BLACKLIST = {s.replace(" ", "").replace("-", "") for s in SKILL_BLACKLIST}
 
-PROMPT_TEMPLATE = """
-**ROLE:** You are an *expert* Career Strategist for **Management Information
-Systems (MIS / YBS)** professionals who also possess strong full-stack and data
-science skills.
-
-**PRIME DIRECTIVE:** The candidate is an MIS student—not a pure software
-developer.  Your analysis *must* prioritise business-technology bridge roles
-(e.g. ERP consultant, process analyst).  Failing to do so is a critical error.
-
-**CONTEXT (read carefully):**
-• Strong full-stack: NestJS, React, TypeScript, Flutter
-• Advanced data analytics & ML (Python / Pandas / XGBoost)
-• ERP & Business-Process focus (SAP, requirement & process improvement)
-• GIS niche (QGIS, PostGIS, Leaflet.js)
-
-**RESUME TEXT:**
----
-{cv_text}
----
-
-**TASK – Return **ONLY** a raw JSON object (no markdown, no commentary).**
-
-1. `"key_skills"`   📋 *array [str]* – top 20-25 skills, ordered by PRIORITY.
-   * **PRIORITY 1 (MUST include):** MIS/Business/Process Skills -> ERP, SAP,
-     business_process_improvement, system_analysis, requirement_analysis,
-     agile, scrum, project_management
-   * **PRIORITY 2:** Core Software & Data Tech -> nestjs, react, python,
-     typescript, postgresql, data_analysis, machine_learning
-   * **PRIORITY 3 (Niche/Supporting):** GIS / Geospatial Skills -> gis, qgis,
-     postgis, leafletjs
-   * Normalise: lowercase, snake_case, no spaces/dashes (`"process_improvement"`).
-
-2. `"target_job_titles"`   🎯 *array [str]* – 12-16 junior / entry / associate
-   titles **ordered by best fit**.
-   **≥ 60 %** of items *must* be MIS / Business / ERP / Data focused. Software roles are secondary.
-   Mandatory buckets (if CV supports):
-   - Business / Process Roles: “Business Analyst”, “Process Analyst”,
-     “Business Systems Analyst”, “Junior Project Manager”
-   - ERP / Consulting Roles: “Junior ERP Consultant”, “IT Consultant”
-   - Hybrid Roles: “Technical Business Analyst”, “Data Analyst”
- - Dev Roles (max 30-40 %): “Full-Stack Developer”, “Mobile Developer (Flutter)”
-  - **GIS Roles (if any, place at the end of the list):** “GIS Specialist”
-
-3. `"skill_importance"`   ⭐ *array [float]* – same length as `key_skills`,
-   values 0.00-1.00 (2 decimals).  Reflect how central the skill is to the
-   candidate’s profile & projects.
-
-4. `"cv_summary"` 🗄 *string* – 2-3 sentence professional summary of the candidate.
-
-**JSON SCHEMA (enforced):**
-{{
-  "type": "object",
- "properties": {{
-    "key_skills":        {{"type": "array", "items": {{"type": "string"}}}},
-    "target_job_titles": {{"type": "array", "items": {{"type": "string"}}}},
-    "skill_importance":  {{"type": "array", "items": {{"type":"number"}}}},
-    "cv_summary":       {{"type": "string"}}
-  }},
-  "required": ["key_skills", "target_job_titles", "skill_importance", "cv_summary"]
-}}
-
-**ABSOLUTE RULES:**
-* Do **NOT** wrap the JSON with ``` or any extra text.
-* Exclude generic office basics (“ms office”, “excel”, “windows”, …).
-* Ensure array lengths match; ordering in `key_skills` ↔ `skill_importance`
-  must correspond.
-"""
+PROMPT_TEMPLATE = load_prompt(PROMPTS_DIR / "cv_analysis_prompt.md")
 
 
 class CVAnalyzer:

--- a/src/data_collector.py
+++ b/src/data_collector.py
@@ -15,12 +15,14 @@ from pathlib import Path
 import pandas as pd
 from jobspy import scrape_jobs
 
+from .constants import SITE_INDEED, SITE_LINKEDIN
+
 logger = logging.getLogger(__name__)
 
 # --- VARSAYILAN AYARLAR ---
 DEFAULT_LOCATION = "Turkey"
 DEFAULT_MAX_RESULTS_PER_SITE = 50  # Her site için ayrı limit
-TARGET_SITES = ["indeed", "linkedin"]  # ÖNEMLİ: LinkedIn öncelikli!
+TARGET_SITES = [SITE_INDEED, SITE_LINKEDIN]  # ÖNEMLİ: LinkedIn öncelikli!
 
 
 def _scrape_single_site(
@@ -36,10 +38,10 @@ def _scrape_single_site(
             "results_wanted": max_results_per_site,
             "hours_old": hours_old,
         }
-        if site == "indeed":
+        if site == SITE_INDEED:
             scrape_params["country_indeed"] = "Turkey"
             logger.info("   🎯 Indeed: Türkiye özel ayarları aktif")
-        elif site == "linkedin":
+        elif site == SITE_LINKEDIN:
             scrape_params["linkedin_fetch_description"] = True
             logger.info("   💼 LinkedIn: Detaylı açıklama ve direkt URL çekiliyor...")
 

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -14,6 +14,7 @@ import pandas as pd
 from tqdm import tqdm
 
 from .config import get_config
+from .constants import PROMPTS_DIR
 from .cv_analyzer import TOKEN_LIMIT, CVAnalyzer
 from .cv_processor import CVProcessor
 from .data_collector import collect_job_data
@@ -24,24 +25,10 @@ from .intelligent_scoring import IntelligentScoringSystem
 from .persona_builder import build_dynamic_personas
 from .reporting import display_results, log_summary_statistics
 from .utils.file_helpers import save_dataframe_csv
+from .utils.prompt_loader import load_prompt
 from .vector_store import VectorStore
 
-RERANK_PROMPT_TEMPLATE = """
-
-You are an expert career assistant. Candidate summary: {cv_summary}
-
-JOB TITLE: {title}
-JOB DESCRIPTION: {description}
-
-Return ONLY JSON with fields:
-{{
-  "fit_score": int,          # 0-100 suitability
-  "is_recommended": bool,    # True if worth applying
-  "reasoning": str,          # short reasoning
-  "matching_keywords": [str],
-  "missing_keywords": [str]
-}}
-"""
+RERANK_PROMPT_TEMPLATE = load_prompt(PROMPTS_DIR / "rerank_prompt.md")
 
 logger = logging.getLogger(__name__)
 

--- a/src/utils/prompt_loader.py
+++ b/src/utils/prompt_loader.py
@@ -6,4 +6,8 @@ from pathlib import Path
 def load_prompt(file_path: str | Path) -> str:
     """Return the prompt text from the given file."""
     path = Path(file_path)
-    return path.read_text(encoding="utf-8")
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        logger.error("Prompt file not found: %s", path, exc_info=True)
+        raise

--- a/src/utils/prompt_loader.py
+++ b/src/utils/prompt_loader.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def load_prompt(file_path: str | Path) -> str:
+    """Return the prompt text from the given file."""
+    path = Path(file_path)
+    return path.read_text(encoding="utf-8")

--- a/src/vector_store.py
+++ b/src/vector_store.py
@@ -16,6 +16,8 @@ import chromadb
 import pandas as pd
 import yaml
 
+from .constants import COSINE_METRIC, DEFAULT_COLLECTION_NAME
+
 logger = logging.getLogger(__name__)
 
 
@@ -42,7 +44,7 @@ class VectorStore:
                     collection_name = cfg.get("vector_store_settings", {}).get("collection_name")
                 except Exception as cfg_err:
                     logger.warning(f"Config load failed: {cfg_err}; using default collection name")
-            self.collection_name = collection_name or "job_embeddings"
+            self.collection_name = collection_name or DEFAULT_COLLECTION_NAME
             self.collection: Any | None = None
             logger.info("VectorStore başarıyla başlatıldı")
 
@@ -67,7 +69,7 @@ class VectorStore:
             # get_or_create_collection kullanarak hem yeni oluşturma hem de mevcut getirme
             self.collection = self.client.get_or_create_collection(
                 name=self.collection_name,
-                metadata={"hnsw:space": "cosine"},  # Cosine similarity kullan
+                metadata={"hnsw:space": COSINE_METRIC},  # Cosine similarity kullan
             )
 
             # Mevcut öğe sayısını kontrol et


### PR DESCRIPTION
Closes #XX

### **1. Summary (Özet)**

Prompts have been moved to dedicated files and a simple loader utility has been introduced. New constants centralize common strings used across modules.

### **2. Problem & Motivation (Problem ve Motivasyon)**

Keeping prompt text inside Python modules made editing cumbersome and scattered magic strings throughout the codebase. This hindered maintainability.

### **3. Solution Implemented (Uygulanan Çözüm)**

- Created `prompts/` directory with separate markdown files for reranking and CV analysis prompts.
- Added `src/utils/prompt_loader.py` for loading prompt files.
- Introduced `src/constants.py` with common string constants.
- Updated `cv_analyzer`, `pipeline`, `data_collector`, and `vector_store` to use the new loader and constants.
- Updated configuration loading in `cv_analyzer` to ensure environment variables from `.env` are available.

### **4. Validation & Testing (Doğrulama ve Test)**

- **Quality Checks:**
  - `ruff`: ✅
  - `mypy`: ✅
  - `bandit`: ✅ (1 low-severity warning)
- **Tests:**
  - `pytest`: ❌ failures remain (`coverage < 75%` and several unit tests failing).


------
https://chatgpt.com/codex/tasks/task_e_685dc657a58c83319c1d159980541b7f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a utility function to load prompt templates from external files for improved flexibility.
  * Centralized configuration values such as collection names, similarity metrics, and job site identifiers.

* **Refactor**
  * Replaced hardcoded string literals with reusable constants throughout the application.
  * Updated prompt templates to be loaded dynamically from external markdown files instead of inline strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->