### PR TITLE
feat: add Streamlit web dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ python main.py
 python main.py --persona Data_Analyst --results 10 --threshold 50
 ```
 
+Alternatif olarak, etkileşimli web arayüzünü başlatmak için aşağıdaki komutu
+kullanabilirsiniz:
+
+```bash
+streamlit run app.py
+```
+
 #### Komut Satırı Seçenekleri
 
 - `--persona`: Sadece belirtilen persona(lar) için arama yapar. Birden fazla persona belirtmek için argümanı tekrarlayın.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,100 @@
+import sys
+from pathlib import Path
+
+import streamlit as st
+
+# Allow imports from the src package
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from src.config import get_config
+from src.pipeline import run_end_to_end_pipeline
+
+config = get_config()
+
+available_personas = list(config.get("persona_search_configs", {}).keys())
+
+st.set_page_config(
+    page_title="AI Career Assistant",
+    page_icon="🚀",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+st.title("🚀 AI Career Assistant")
+st.markdown("Discover your next career opportunity with the power of AI.")
+
+if "job_results" not in st.session_state:
+    st.session_state.job_results = None
+if "is_running" not in st.session_state:
+    st.session_state.is_running = False
+
+sidebar = st.sidebar
+sidebar.header("⚙️ Analysis Configuration")
+
+st.session_state.similarity_threshold = sidebar.slider(
+    "Similarity Threshold (%)",
+    min_value=40,
+    max_value=100,
+    value=config["job_search_settings"].get("min_similarity_threshold", 60),
+)
+
+hours_option = sidebar.selectbox(
+    "Date Range",
+    options=[("Last 24 hours", 24), ("Last 3 days", 72), ("Last 7 days", 168)],
+    format_func=lambda x: x[0],
+)
+
+st.session_state.hours_old = hours_option[1]
+
+selected_personas = sidebar.multiselect(
+    "Personas",
+    options=available_personas,
+    default=available_personas,
+)
+
+if sidebar.button("🤖 Find My Perfect Jobs", type="primary", use_container_width=True):
+    st.session_state.is_running = True
+    st.session_state.job_results = None
+
+if st.session_state.is_running:
+    with st.spinner("Analyzing your CV against the job market... This may take a few minutes. ⏳"):
+        try:
+            results = run_end_to_end_pipeline(
+                selected_personas=selected_personas or None,
+                similarity_threshold=st.session_state.similarity_threshold,
+                hours_old=st.session_state.hours_old,
+            )
+            st.session_state.job_results = results
+            st.session_state.is_running = False
+            st.success(f"Analysis complete! Found {len(results) if results else 0} suitable opportunities.")
+            st.balloons()
+        except Exception as exc:  # pragma: no cover - visual feedback
+            st.session_state.is_running = False
+            st.error(f"An error occurred during analysis: {exc}")
+
+results = st.session_state.job_results
+if results:
+    for job in results:
+        st.subheader(job.get("title", "No Title"))
+        col1, col2, col3 = st.columns(3)
+        score = job.get("fit_score", job.get("similarity_score", 0))
+        col1.metric("Fit Score", f"{score:.1f}")
+        col2.metric("Source", job.get("source_site", "N/A"))
+        col3.metric("Persona", job.get("persona_source", "N/A"))
+
+        with st.expander("AI Insights"):
+            reasoning = job.get("reasoning")
+            if reasoning:
+                st.write(reasoning)
+            mk = job.get("matching_keywords")
+            if mk:
+                st.write("**Matching Skills:**", ", ".join(mk))
+            miss = job.get("missing_keywords")
+            if miss:
+                st.write("**Missing Skills:**", ", ".join(miss))
+        url = job.get("url") or job.get("job_url")
+        if url:
+            st.link_button("View Job", url)
+        st.divider()
+elif results is not None:
+    st.info("No suitable jobs found.")

--- a/prompts/cv_analysis_prompt.md
+++ b/prompts/cv_analysis_prompt.md
@@ -47,16 +47,16 @@ developer.  Your analysis *must* prioritise business-technology bridge roles
 4. `"cv_summary"` 🗄 *string* – 2-3 sentence professional summary of the candidate.
 
 **JSON SCHEMA (enforced):**
-{
+{{
   "type": "object",
- "properties": {
-    "key_skills":        {"type": "array", "items": {"type": "string"}},
-    "target_job_titles": {"type": "array", "items": {"type": "string"}},
-    "skill_importance":  {"type": "array", "items": {"type":"number"}},
-    "cv_summary":       {"type": "string"}
-  },
+  "properties": {{
+    "key_skills":        {{"type": "array", "items": {{"type": "string"}}}},
+    "target_job_titles": {{"type": "array", "items": {{"type": "string"}}}},
+    "skill_importance":  {{"type": "array", "items": {{"type":"number"}}}},
+    "cv_summary":       {{"type": "string"}}
+  }},
   "required": ["key_skills", "target_job_titles", "skill_importance", "cv_summary"]
-}
+}}
 
 **ABSOLUTE RULES:**
 * Do **NOT** wrap the JSON with ``` or any extra text.

--- a/src/models/pipeline_context.py
+++ b/src/models/pipeline_context.py
@@ -24,3 +24,4 @@ class PipelineContext:
     scored_jobs: list[dict[str, Any]] = field(default_factory=list)
     final_results: list[dict[str, Any]] = field(default_factory=list)
     scoring_system: IntelligentScoringSystem | None = None
+    hours_old: int | None = None

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -177,8 +177,8 @@ def collect_data_for_all_personas(context: PipelineContext) -> str | None:
 
     for persona_name, persona_cfg in tqdm(personas, desc="Persona Aramaları"):
         cfg_for_run = persona_cfg.copy()
-        if context.cli_args.hours_old is not None:
-            cfg_for_run["hours_old"] = context.cli_args.hours_old
+        if context.hours_old is not None:
+            cfg_for_run["hours_old"] = context.hours_old
         jobs_df = _collect_jobs_for_persona(persona_name, cfg_for_run, context)
         if jobs_df is not None:
             all_collected_jobs_list.append(jobs_df)


### PR DESCRIPTION
Closes #XX

### **1. Summary (Özet)**

Adds a new `app.py` Streamlit interface and updates the pipeline to return results for interactive use.

### **2. Problem & Motivation (Problem ve Motivasyon)**

The assistant only ran from the command line. There was no simple way to run the analysis interactively or adjust parameters without editing the CLI.

### **3. Solution Implemented (Uygulanan Çözüm)**

- Created `app.py` providing a basic Streamlit dashboard with configurable controls.
- Refactored `run_end_to_end_pipeline` and helpers to return job results and accept `hours_old`.
- Added `hours_old` to `PipelineContext` and propagated through collection functions.
- Escaped JSON braces in the CV analysis prompt.
- Documented how to launch the web UI in the README.

### **4. Validation & Testing (Doğrulama ve Test)**

- **Quality Checks:**
  - `ruff format` and `ruff check`: ✅
  - `mypy`: ✅
  - `bandit`: ✅
- **Tests:**
  - `pytest`: ❌ (tests could not complete due to network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_685e131fac3883319a04c6a127537590

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for filtering job results by the age of job postings with an optional parameter.
  
* **Bug Fixes**
  * Enhanced error handling to return no results on failures, preventing partial or invalid data from being shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->